### PR TITLE
Add tenant limits allowlist filtering

### DIFF
--- a/docs/sources/shared/configuration.md
+++ b/docs/sources/shared/configuration.md
@@ -1515,6 +1515,9 @@ ingest_limits_frontend_client:
 # This setting is deprecated and will be removed in the next minor release.
 # CLI flag: -metrics-namespace
 [metrics_namespace: <string> | default = "loki"]
+# Comma-separated list of limits returned by /config/tenant/v1/limits
+# CLI flag: -tenant-limits.allowlist
+[tenant_limits_allowlist: <list of strings> | default = []]
 ```
 
 ### alibabacloud_storage_config


### PR DESCRIPTION
## Summary
- expose `tenant_limits_allowlist` option in config
- make `/config/tenant/v1/limits` filterable by allow list
- document new option
- test tenant limits allowlist behaviour

## Testing
- `go test ./pkg/loki -run TestTenantLimitsHandlerAllowlist -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687e980c607c8331aa0d7fd8763d3675